### PR TITLE
Fix import path in mcp_cli.py

### DIFF
--- a/src/mcp_cli.py
+++ b/src/mcp_cli.py
@@ -9,7 +9,7 @@ verzoeken naar MCP servers, zowel lokaal (via STDIO) als remote (via SSE).
 import argparse
 import json
 import sys
-from mcp_client import MCPClient, log
+from src.mcp_client import MCPClient, log
 
 def main():
     """Hoofdfunctie voor de MCP CLI."""


### PR DESCRIPTION
Dit lost issue #1 op door het importpad in mcp_cli.py aan te passen.

## Wat is er gedaan
- De import-regel in src/mcp_cli.py is gewijzigd van `from mcp_client import MCPClient, log` naar `from src.mcp_client import MCPClient, log`
- Deze relatieve import zorgt voor consistentie en maakt het mogelijk om de CLI correct te starten vanuit de project root directory

## Tests
- Handmatig geverifieerd dat de CLI correct start zonder import-gerelateerde fouten
- Zowel lokale als remote verbindingsmodi werken zoals verwacht
- Alle functionaliteit blijft behouden

## Voltooid
Dit lost issue #1 volledig op en maakt de module structuur van het project robuuster.

Fixes #1