### PR TITLE
Implementeer entrypoint script (main.py)

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+"""
+MCP CLI Client - Entrypoint Script
+
+Dit is het hoofdentrypoint voor de MCP CLI Client applicatie. 
+Door dit script uit te voeren vanaf de projectroot, kunnen gebruikers eenvoudig
+toegang krijgen tot alle functionaliteit zonder zich zorgen te maken over Python
+module-importpaden.
+"""
+
+import sys
+from src.mcp_cli import main as cli_main
+
+
+if __name__ == "__main__":
+    """
+    Start de MCP CLI applicatie.
+    Alle command-line argumenten worden doorgegeven aan de mcp_cli module.
+    """
+    try:
+        cli_main()
+    except KeyboardInterrupt:
+        print("\nProgramma onderbroken door gebruiker")
+        sys.exit(0)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)


### PR DESCRIPTION
Dit lost issue #3 op door het toevoegen van een centraal entrypoint script in de root van het project.

## Wat is er gedaan
- Een nieuw main.py bestand is toegevoegd in de project root
- Het script importeert en roept de `main()` functie aan van src/mcp_cli.py
- Extra foutafhandeling is toegevoegd voor interrupts en algemene exceptions

## Tests
- Handmatig geverifieerd dat het script kan worden uitgevoerd met `python main.py`
- Getest dat alle bestaande command-line opties blijven werken
- Getest dat het script correct werkt in interactieve modus

## Voltooid
Dit lost issue #3 volledig op en maakt de applicatie gebruiksvriendelijker door een eenvoudig entrypoint beschikbaar te maken.

Fixes #3