### PR TITLE
Voeg ondersteuning voor gebruik als Python module toe

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ De MCP CLI Client stelt gebruikers in staat om:
 - Te verbinden met remote MCP-servers via SSE (Server-Sent Events)
 - JSON-RPC verzoeken te sturen naar verbonden servers
 - Te werken in zowel command-line modus als interactieve modus
+- Als een Python module te integreren in andere projecten
 
 ## Installatie
 
@@ -35,19 +36,24 @@ De MCP CLI Client stelt gebruikers in staat om:
    # Bewerk .env met je eigen configuratie
    ```
 
-## Gebruik
+5. Om als Python pakket te installeren:
+   ```bash
+   pip install -e .
+   ```
+
+## Gebruik als Command Line Tool
 
 ### Basis commando's
 
 ```bash
 # Verbinden met een lokale MCP-server en een verzoek uitvoeren
-python -m src.mcp_cli --local --method methodName --params '{"param1": "value1"}'
+python main.py --local --method methodName --params '{"param1": "value1"}'
 
 # Verbinden met een remote MCP-server en een verzoek uitvoeren
-python -m src.mcp_cli --remote --method methodName --params '{"param1": "value1"}'
+python main.py --remote --method methodName --params '{"param1": "value1"}'
 
 # Starten in interactieve modus met een lokale server
-python -m src.mcp_cli --local
+python main.py --local
 ```
 
 ### Interactieve modus
@@ -59,6 +65,49 @@ methodName {"param1": "value1", "param2": "value2"}
 
 Typ `exit`, `quit` of `q` om de interactieve modus te verlaten.
 
+## Gebruik als Python Module
+
+De MCP CLI Client kan ook worden gebruikt als een Python module in je eigen projecten:
+
+```python
+from mcp_cli_client import MCPClient
+
+# Maak een nieuwe client instantie
+client = MCPClient()
+
+# Verbind met een lokale MCP server
+client.connect_stdio("path/to/local/mcp/server")
+# OF verbind met een remote server
+# client.connect_sse("https://mcp-server.example.com/events")
+
+# Stuur verzoeken
+response = client.send_request("getVersion")
+print(response)
+
+# Stuur verzoeken met parameters
+response = client.send_request("echo", {"message": "Hello, MCP!"})
+print(response)
+
+# Sluit de verbinding
+client.close()
+```
+
+### Installatie als module
+
+Om de MCP CLI Client als module te installeren in andere projecten:
+
+```bash
+# Vanuit de repo directory
+pip install -e .
+
+# OF direct vanaf GitHub
+pip install git+https://github.com/Fbeunder/MCP_CLI_CLIENT.git
+```
+
+### Uitgebreid voorbeeld
+
+Bekijk `examples/module_example.py` voor een uitgebreid voorbeeld van het gebruik als module.
+
 ## Configuratie
 
 Configuratie wordt geladen uit het `.env` bestand, met de volgende opties:
@@ -67,6 +116,23 @@ Configuratie wordt geladen uit het `.env` bestand, met de volgende opties:
 - `MCP_LOCAL_COMMAND`: Opdracht om een lokale server te starten via STDIO
 - `API_KEY`: Optionele API-sleutel voor authenticatie
 - `LOG_LEVEL`: Logniveau (DEBUG, INFO, ERROR)
+
+## API Documentatie
+
+### MCPClient
+
+De `MCPClient` klasse biedt de volgende methoden:
+
+- `connect_stdio(command=None)`: Verbind met een lokale MCP server via STDIO
+- `connect_sse(url=None)`: Verbind met een remote MCP server via SSE
+- `send_request(method, params=None)`: Stuur een JSON-RPC verzoek
+- `close()`: Sluit de verbinding
+
+### Exceptions
+
+- `ConfigurationError`: Fout bij laden of verwerken van configuratie
+- `ConnectionError`: Fout bij het maken van een verbinding
+- `CommunicationError`: Fout bij communicatie met de MCP server
 
 ## Licentie
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,10 @@
+"""
+MCP CLI Client Root Package
+
+Dit package maakt het mogelijk om de MCP CLI client te gebruiken als een Python module.
+"""
+
+from src.mcp_client import MCPClient, log, ConfigurationError, ConnectionError, CommunicationError
+
+# Versie informatie
+__version__ = "0.1.0"

--- a/examples/module_example.py
+++ b/examples/module_example.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+"""
+MCP CLI Client Module Usage Example
+
+Dit script demonstreert hoe de MCP CLI Client te gebruiken als een Python module
+in een ander Python project. Het toont zowel lokale als remote verbindingen
+en het versturen van JSON-RPC verzoeken.
+"""
+
+import os
+import json
+from dotenv import load_dotenv
+from mcp_cli_client import MCPClient, log
+
+def main():
+    """
+    Demonstreert het gebruik van de MCP CLI Client als Python module.
+    """
+    # Laad configuratie uit .env bestand
+    load_dotenv()
+    
+    # Maak een nieuwe MCPClient instantie
+    client = MCPClient()
+    
+    try:
+        # Voorbeeld 1: Verbind met een lokale MCP server
+        local_command = os.getenv("MCP_LOCAL_COMMAND")
+        if local_command:
+            print(f"Verbinden met lokale MCP server: {local_command}")
+            if client.connect_stdio(local_command):
+                # Verstuur een getVersion verzoek
+                response = client.send_request("getVersion")
+                print("Resultaat van getVersion verzoek:")
+                print(json.dumps(response, indent=2))
+                
+                # Verstuur een tweede verzoek met parameters
+                response = client.send_request("echo", {"message": "Hallo van Python module!"})
+                print("Resultaat van echo verzoek:")
+                print(json.dumps(response, indent=2))
+                
+                # Sluit de verbinding
+                client.close()
+        
+        # Voorbeeld 2: Verbind met een remote MCP server via SSE
+        remote_url = os.getenv("MCP_SERVER_URL")
+        if remote_url:
+            print(f"Verbinden met remote MCP server: {remote_url}")
+            if client.connect_sse(remote_url):
+                # Verstuur een getStatus verzoek
+                response = client.send_request("getStatus")
+                print("Resultaat van getStatus verzoek:")
+                print(json.dumps(response, indent=2))
+                
+                # Sluit de verbinding
+                client.close()
+    except Exception as e:
+        print(f"Fout: {e}")
+    finally:
+        # Zorg dat de verbinding altijd wordt afgesloten
+        if 'client' in locals():
+            client.close()
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="mcp_cli_client",
+    version="0.1.0",
+    description="Een Python client voor het werken met MCP (Machine Communication Protocol) servers",
+    author="Fbeunder",
+    author_email="",
+    url="https://github.com/Fbeunder/MCP_CLI_CLIENT",
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[
+        "requests",
+        "python-dotenv",
+    ],
+    entry_points={
+        "console_scripts": [
+            "mcp-cli=main:main",
+        ],
+    },
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+    python_requires=">=3.7",
+)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,7 @@
-# MCP CLI Client Package
+"""
+MCP CLI Client Package
+
+Dit package bevat modules voor het verbinden en communiceren met MCP-servers.
+"""
+
+from src.mcp_client import MCPClient, log, ConfigurationError, ConnectionError, CommunicationError


### PR DESCRIPTION
## Beschrijving
Deze PR implementeert ondersteuning voor het gebruik van de MCP CLI Client als een Python module in andere projecten. Dit maakt het mogelijk om de client te importeren en programmatisch te gebruiken zonder de command-line interface.

## Wijzigingen
- Toegevoegde `__init__.py` bestanden om het project importeerbaar te maken als een Python pakket
- Toegevoegd `setup.py` bestand voor pip-installatie
- Een voorbeeldscript toegevoegd in `examples/module_example.py` dat laat zien hoe de client te gebruiken als een Python module
- README.md bijgewerkt met documentatie over het gebruik als module, inclusief code voorbeelden en API documentatie

## Testen
Handmatig getest:
- Installatie via `pip install -e .`
- Import functionaliteit via `from mcp_cli_client import MCPClient`
- Voorbeeld codegebruik volgens README instructies

Fixes #7